### PR TITLE
Use custom scale type & modifier instead of direct scale setting

### DIFF
--- a/src/main/java/moriyashiine/extraorigins/common/ExtraOrigins.java
+++ b/src/main/java/moriyashiine/extraorigins/common/ExtraOrigins.java
@@ -3,6 +3,7 @@ package moriyashiine.extraorigins.common;
 import moriyashiine.extraorigins.common.network.packet.BoneMealPacket;
 import moriyashiine.extraorigins.common.registry.EOConditions;
 import moriyashiine.extraorigins.common.registry.EOPowers;
+import moriyashiine.extraorigins.common.registry.EOScaleTypes;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 
@@ -12,6 +13,7 @@ public class ExtraOrigins implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		ServerPlayNetworking.registerGlobalReceiver(BoneMealPacket.ID, BoneMealPacket::handle);
+		EOScaleTypes.init();
 		EOPowers.init();
 		EOConditions.init();
 	}

--- a/src/main/java/moriyashiine/extraorigins/common/power/ModifySizePower.java
+++ b/src/main/java/moriyashiine/extraorigins/common/power/ModifySizePower.java
@@ -2,12 +2,11 @@ package moriyashiine.extraorigins.common.power;
 
 import io.github.apace100.origins.power.Power;
 import io.github.apace100.origins.power.PowerType;
+import moriyashiine.extraorigins.common.registry.EOScaleTypes;
 import net.minecraft.entity.player.PlayerEntity;
-import virtuoel.pehkui.api.ScaleType;
+import virtuoel.pehkui.api.ScaleData;
 
 public class ModifySizePower extends Power {
-	private static final ScaleType[] MODIFY_SIZE_TYPES = {ScaleType.WIDTH, ScaleType.HEIGHT, ScaleType.DROPS};
-	
 	public final float scale;
 	
 	public ModifySizePower(PowerType<?> type, PlayerEntity player, float scale) {
@@ -18,16 +17,14 @@ public class ModifySizePower extends Power {
 	@Override
 	public void onAdded() {
 		super.onAdded();
-		for (ScaleType type : MODIFY_SIZE_TYPES) {
-			type.getScaleData(player).setScale(type.getScaleData(player).getScale() * scale);
-		}
+		ScaleData data = EOScaleTypes.MODIFY_SIZE_TYPE.getScaleData(player);
+		data.setScale(data.getBaseScale() * scale);
 	}
 	
 	@Override
 	public void onRemoved() {
 		super.onRemoved();
-		for (ScaleType type : MODIFY_SIZE_TYPES) {
-			type.getScaleData(player).setScale(type.getScaleData(player).getScale() / scale);
-		}
+		ScaleData data = EOScaleTypes.MODIFY_SIZE_TYPE.getScaleData(player);
+		data.setScale(data.getBaseScale() / scale);
 	}
 }

--- a/src/main/java/moriyashiine/extraorigins/common/registry/EOScaleTypes.java
+++ b/src/main/java/moriyashiine/extraorigins/common/registry/EOScaleTypes.java
@@ -1,0 +1,52 @@
+package moriyashiine.extraorigins.common.registry;
+
+import java.util.Map;
+
+import moriyashiine.extraorigins.common.ExtraOrigins;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.Identifier;
+import virtuoel.pehkui.api.ScaleData;
+import virtuoel.pehkui.api.ScaleModifier;
+import virtuoel.pehkui.api.ScaleRegistries;
+import virtuoel.pehkui.api.ScaleType;
+
+public class EOScaleTypes {
+	public static final ScaleModifier MODIFY_SIZE_MODIFIER = register(ScaleRegistries.SCALE_MODIFIERS, "modify_size", new ScaleModifier() {
+		@Override
+		public float modifyScale(final ScaleData scaleData, float modifiedScale, final float delta) {
+			return MODIFY_SIZE_TYPE.getScaleData(scaleData.getEntity()).getScale(delta) * modifiedScale;
+		}
+	});
+	
+	public static final ScaleType MODIFY_SIZE_TYPE = register(ScaleRegistries.SCALE_TYPES, "modify_size", ScaleType.Builder.create().build());
+	
+	private static <T> T register(Map<Identifier, T> registry, String name, T entry) {
+		return ScaleRegistries.register(registry, new Identifier(ExtraOrigins.MODID, name), entry);
+	}
+	
+	private static final ScaleType[] MODIFIED_SIZE_TYPES = { ScaleType.WIDTH, ScaleType.HEIGHT, ScaleType.DROPS };
+	
+	public static void init() {
+		for (ScaleType type : MODIFIED_SIZE_TYPES) {
+			type.getDefaultBaseValueModifiers().add(MODIFY_SIZE_MODIFIER);
+		}
+		
+		MODIFY_SIZE_TYPE.getScaleChangedEvent().register(s -> {
+			Entity e = s.getEntity();
+			
+			if (e != null) {
+				boolean onGround = e.isOnGround();
+				e.calculateDimensions();
+				e.setOnGround(onGround);
+				
+				for (ScaleType scaleType : ScaleRegistries.SCALE_TYPES.values()) {
+					ScaleData data = scaleType.getScaleData(e);
+					
+					if (data.getBaseValueModifiers().contains(MODIFY_SIZE_MODIFIER)) {
+						data.markForSync(true);
+					}
+				}
+			}
+		});
+	}
+}


### PR DESCRIPTION
This changes the size power to use a custom scale type and scale modifier, providing better inter-mod compatibility over directly modifying existing scales, as well as removing the scale changes if the mod is removed. 

(A similar change could probably be done in Bewitchment to the size changing of Vampires and Werewolves as well)