### PR TITLE
Do not hard code health level changes (use multiplier instead)

### DIFF
--- a/src/main/resources/data/extraorigins/powers/bite_sized.json
+++ b/src/main/resources/data/extraorigins/powers/bite_sized.json
@@ -10,7 +10,7 @@
 	  {
 		"name": "Origin modifier",
 		"attribute": "generic.max_health",
-		"operation": "multiply_total",
+		"operation": "multiply_base",
 		"value": 0.5
 	  },
 	  {

--- a/src/main/resources/data/extraorigins/powers/bite_sized.json
+++ b/src/main/resources/data/extraorigins/powers/bite_sized.json
@@ -10,8 +10,8 @@
 	  {
 		"name": "Origin modifier",
 		"attribute": "generic.max_health",
-		"operation": "addition",
-		"value": -10
+		"operation": "multiply_total",
+		"value": 0.5
 	  },
 	  {
 		"name": "Origin modifier",

--- a/src/main/resources/data/extraorigins/powers/bite_sized.json
+++ b/src/main/resources/data/extraorigins/powers/bite_sized.json
@@ -11,7 +11,7 @@
 		"name": "Origin modifier",
 		"attribute": "generic.max_health",
 		"operation": "multiply_base",
-		"value": 0.5
+		"value": -0.5
 	  },
 	  {
 		"name": "Origin modifier",

--- a/src/main/resources/data/extraorigins/powers/flabby.json
+++ b/src/main/resources/data/extraorigins/powers/flabby.json
@@ -3,7 +3,7 @@
   "modifier": {
 	"name": "Origin modifier",
 	"attribute": "generic.max_health",
-	"operation": "addition",
-	"value": -4
+	"operation": "multiply_total",
+	"value": 0.8
   }
 }

--- a/src/main/resources/data/extraorigins/powers/flabby.json
+++ b/src/main/resources/data/extraorigins/powers/flabby.json
@@ -4,6 +4,6 @@
 	"name": "Origin modifier",
 	"attribute": "generic.max_health",
 	"operation": "multiply_total",
-	"value": 0.8
+	"value": -0.8
   }
 }

--- a/src/main/resources/data/extraorigins/powers/flabby.json
+++ b/src/main/resources/data/extraorigins/powers/flabby.json
@@ -3,7 +3,7 @@
   "modifier": {
 	"name": "Origin modifier",
 	"attribute": "generic.max_health",
-	"operation": "multiply_total",
-	"value": -0.8
+	"operation": "multiply_base",
+	"value": 0.8
   }
 }

--- a/src/main/resources/data/extraorigins/powers/flabby.json
+++ b/src/main/resources/data/extraorigins/powers/flabby.json
@@ -4,6 +4,6 @@
 	"name": "Origin modifier",
 	"attribute": "generic.max_health",
 	"operation": "multiply_base",
-	"value": 0.8
+	"value": -0.2
   }
 }


### PR DESCRIPTION
Instead of removing e.g. 10 health levels to start with 5 hearts, 50% of the health level should be used. This way, the mod becomes more compatible to other mods like spiceoffabric or healthlevels, without changing the original idea of the reduced health level.

Currently, when starting a world with spiceoffabric in carrot mode, the inchling will only have one heart, because spiceoffabric reduces the health level by 8 (pr open to make it use 60%  hl's instead of always reducing the hl by 8). Then, this mod reduces it by another 10 to only 2 left.

This could also lead to a case where the player had negetive health levels.
This can be prevented by using a multiplier: spiceoffabric sets it to 60% of 20 = 12, extra-origins sets it to 50% of this, leaving the player with 6 hl's or 3 hearts.


Another example:
Let's say I have 3 mods: origins, spiceoffabric and healthlevels.

Currently,
Healthlevels sets the starting hl to 10. Spiceoffabric then reduces it by 8. origins reduces it by 10 again.
The player is left with -8 health levels.

With these changes, healthlevels would still reduce it by 10 to 10 (wil create a pr there to fix this as well), but spiceoffabric sets the hl to 60% of that (6), and origins to 50% of this (3), so the player is left with 1.5 hearts, instead of negative hearts.

The proposed changes are tested and are confirmed to work as expected. though, additional testing is off course welcome as well as comments or ideas to improve mod compatibility even more.
An equivilant pull request will be opened for the base origin mod.


This pull request might need a change in the description of the power, as it's technically not "5 hearts less" anymore but "50% of the hearts", though it doesn't make a change without additional mods changing the health level (same for piglin).