### PR TITLE
Update to 1.20.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ repositories {
         url "https://maven.shedaniel.me"
     }
     maven {
+        name "quiltmc"
+        url "https://maven.quiltmc.org/repository/release"
+    }
+    maven {
         name "mod menu"
         url "https://maven.terraformersmc.com"
     }
@@ -30,6 +34,10 @@ repositories {
     maven {
         name "jitpack"
         url "https://jitpack.io"
+    }
+    maven {
+        name "modrinth"
+        url "https://api.modrinth.com/maven"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ repositories {
         url "https://maven.ladysnake.org/releases"
     }
     maven {
+        name "masady"
+        url "https://masa.dy.fi/maven"
+    }
+    maven {
         name "reach entity attributes"
         url "https://maven.jamieswhiteshirt.com/libs-release"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,12 @@ org.gradle.parallel=true
 # Fabric Properties
 minecraft_version=1.20.2
 yarn_mappings=1.20.2+build.4
-loader_version=0.14.24
+loader_version=0.15.3
 # Mod Properties
 mod_version=1.20-3
 maven_group=moriyashiine
 archives_base_name=extraorigins
 # Dependencies
-fabric_version=0.90.4+1.20.2
-origins_version=v1.11.3
-pehkui_version=3.7.11
+fabric_version=0.91.3+1.20.2
+origins_version=v1.12.0
+pehkui_version=3.7.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,6 @@ mod_version=1.20-3
 maven_group=moriyashiine
 archives_base_name=extraorigins
 # Dependencies
-fabric_version=0.91.3+1.20.2
+fabric_version=0.91.1+1.20.2
 origins_version=v1.12.0
 pehkui_version=3.7.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@
 org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 # Fabric Properties
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
-loader_version=0.14.22
+minecraft_version=1.20.2
+yarn_mappings=1.20.2+build.4
+loader_version=0.14.24
 # Mod Properties
 mod_version=1.20-3
 maven_group=moriyashiine
 archives_base_name=extraorigins
 # Dependencies
-fabric_version=0.89.3+1.20.1
-origins_version=0dfec42
-pehkui_version=3.7.8
+fabric_version=0.90.4+1.20.2
+origins_version=v1.11.3
+pehkui_version=3.7.11

--- a/src/main/java/moriyashiine/extraorigins/mixin/SuspiciousStewItemMixin.java
+++ b/src/main/java/moriyashiine/extraorigins/mixin/SuspiciousStewItemMixin.java
@@ -4,10 +4,11 @@
 
 package moriyashiine.extraorigins.mixin;
 
+import com.google.common.collect.ImmutableList;
 import io.github.apace100.apoli.component.PowerHolderComponent;
 import moriyashiine.extraorigins.common.power.FoodEffectImmunityPower;
+import net.minecraft.block.SuspiciousStewIngredient;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SuspiciousStewItem;
 import net.minecraft.world.World;
@@ -17,6 +18,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
 
 @Mixin(SuspiciousStewItem.class)
 public class SuspiciousStewItemMixin {
@@ -33,13 +36,14 @@ public class SuspiciousStewItemMixin {
 		tempLiving = null;
 	}
 
-	@ModifyVariable(method = "forEachEffect", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/entity/effect/StatusEffect;byRawId(I)Lnet/minecraft/entity/effect/StatusEffect;"))
-	private static StatusEffect extraorigins$foodEffectImmunity(StatusEffect value) {
-		for (FoodEffectImmunityPower foodEffectImmunityPower : PowerHolderComponent.getPowers(tempLiving, FoodEffectImmunityPower.class)) {
-			if (foodEffectImmunityPower.shouldRemove(value)) {
-				return null;
+	@ModifyVariable(method = "method_53207", at = @At("HEAD"), argsOnly = true)
+	private static List<SuspiciousStewIngredient.StewEffect> extraorigins$foodEffectImmunity(List<SuspiciousStewIngredient.StewEffect> list) {
+		ImmutableList.Builder<SuspiciousStewIngredient.StewEffect> newList = ImmutableList.builder();
+		for (SuspiciousStewIngredient.StewEffect stewEffect : list) {
+			if (PowerHolderComponent.getPowers(tempLiving, FoodEffectImmunityPower.class).stream().noneMatch(foodEffectImmunityPower -> foodEffectImmunityPower.shouldRemove(stewEffect.effect()))) {
+				newList.add(stewEffect);
 			}
 		}
-		return value;
+		return newList.build();
 	}
 }

--- a/src/main/java/moriyashiine/extraorigins/mixin/SuspiciousStewItemMixin.java
+++ b/src/main/java/moriyashiine/extraorigins/mixin/SuspiciousStewItemMixin.java
@@ -38,12 +38,15 @@ public class SuspiciousStewItemMixin {
 
 	@ModifyVariable(method = "method_53207", at = @At("HEAD"), argsOnly = true)
 	private static List<SuspiciousStewIngredient.StewEffect> extraorigins$foodEffectImmunity(List<SuspiciousStewIngredient.StewEffect> list) {
-		ImmutableList.Builder<SuspiciousStewIngredient.StewEffect> newList = ImmutableList.builder();
-		for (SuspiciousStewIngredient.StewEffect stewEffect : list) {
-			if (PowerHolderComponent.getPowers(tempLiving, FoodEffectImmunityPower.class).stream().noneMatch(foodEffectImmunityPower -> foodEffectImmunityPower.shouldRemove(stewEffect.effect()))) {
-				newList.add(stewEffect);
+		if (PowerHolderComponent.hasPower(tempLiving, FoodEffectImmunityPower.class)) {
+			ImmutableList.Builder<SuspiciousStewIngredient.StewEffect> newList = ImmutableList.builder();
+			for (SuspiciousStewIngredient.StewEffect stewEffect : list) {
+				if (PowerHolderComponent.getPowers(tempLiving, FoodEffectImmunityPower.class).stream().noneMatch(foodEffectImmunityPower -> foodEffectImmunityPower.shouldRemove(stewEffect.effect()))) {
+					newList.add(stewEffect);
+				}
 			}
+			return newList.build();
 		}
-		return newList.build();
+		return list;
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,10 +31,10 @@
   ],
   "depends": {
 	"fabricloader": "*",
-	"minecraft": "~1.20.1",
+	"minecraft": "~1.20.2",
 	"java": ">=17",
-	"fabric-api": ">=0.83.1",
-	"origins": ">=1.10.0",
-	"pehkui": ">=3.7.6"
+	"fabric-api": ">=0.89.2",
+	"origins": ">=1.11.0",
+	"pehkui": ">=3.7.9"
   }
 }


### PR DESCRIPTION
- Added QuiltMC maven to the repositories block in build.gradle, this was required for their build of GSON, which Origins now uses.
- Added Modrinth maven to the repositories block in build.gradle, now required for Additional Entity Attributes.
- Fixed foodEffectImmunity ModifyVariable inside SuspiciousStewItemMixin, there was an internal change to suspicious stew. Hopefully you don't mind my use of noneMatch, I found streams to be the most efficient here. 
The list was immutable, which is why I went the rebuild route.

I have not messed with the versioning of the mod, you'll have to increment that yourself. :3